### PR TITLE
Add attribute modifier notes per datajoint-python/issues/354.

### DIFF
--- a/data-definition/Data-types.md
+++ b/data-definition/Data-types.md
@@ -44,7 +44,7 @@ In DataJoint, there are three ways to impose a unique constraint.
 
  * Make it the primary key. We have seen some designs with a surrogate primary key with autoincrement and then a separate unique index on the natural attributes. In some cases, a better design is to use the unique fields as the primary key instead.
 
- * Use a `UNIQUE INDEX (...)` line in the declaration. This is documented in [definition syntax](Definition-syntax.html). It works the same way as in SQL, however it's more general than the UNIQUE modifier on a field since it can be applied to any number of attributes.
+ * Use a `UNIQUE INDEX (...)` line in the declaration. This is documented in [definition syntax](Definition-syntax.html). This creates a unique constraint on the given attributes and indexes the combination for faster queries.
 
- * Use the unique option in the foreign key (datajoint >v0.8.1). This is documented in [foreign keys](Foreign-keys.html). This is the preferred way since it is consonant with the concept that DataJoint keeps the focus on entities rather than attributes.
+ * Use the unique option in the foreign key (datajoint >v0.9.0). This is documented in [foreign keys](Foreign-keys.html). This is the preferred way since it is consonant with the concept that DataJoint keeps the focus on entities rather than attributes.
 

--- a/data-definition/Data-types.md
+++ b/data-definition/Data-types.md
@@ -35,3 +35,16 @@ DataJoint supports the following datatypes. Use the smallest most restrictive da
  * `bit`
 
 For additional information about these datatypes, see http://dev.mysql.com/doc/refman/5.6/en/data-types.html
+
+## A note on fields and MySQL
+
+Currently, DataJoint simply passes field declarations to MySQL without parsing it to restrict the use of SQL's modifiers such as `DEFAULT`, `NOT NULL`, and `UNIQUE`. However, DataJoint provides its way to implement each of these features in its own way and so it is best to use these features.
+
+In DataJoint, there are three ways to impose a unique constraint.
+
+ * Make it the primary key. We have seen some designs with a surrogate primary key with autoincrement and then a separate unique index on the natural attributes. In some cases, a better design is to use the unique fields as the primary key instead.
+
+ * Use a `UNIQUE INDEX (...)` line in the declaration. This is documented in [definition syntax](Definition-syntax.html). It works the same way as in SQL, however it's more general than the UNIQUE modifier on a field since it can be applied to any number of attributes.
+
+ * Use the unique option in the foreign key (datajoint >v0.8.1). This is documented in [foreign keys](Foreign-keys.html). This is the preferred way since it is consonant with the concept that DataJoint keeps the focus on entities rather than attributes.
+

--- a/data-definition/Definition-syntax.rst
+++ b/data-definition/Definition-syntax.rst
@@ -1,6 +1,5 @@
 Definition syntax 
 =================
-.. todo?: provide unique index example?
 
 The table definition consist of lines.  Each line can be one of the following:
 
@@ -13,7 +12,7 @@ The table definition consist of lines.  Each line can be one of the following:
   - ``name = default : datatype  # comment``
 * The divider ``---`` (at least three dashes) separating primary key attributes above from non-primary attributes below.
 * A foreign key in the format ``-> ReferencedTable``. (See :doc:`Foreign-keys`.)
-* A ``unique index`` attribute modifier in the format ``unique index(attribute, ...)``.
+* A ``unique index`` declaration in the format ``unique index(attribute, ...)``.
 
 For example, the table for Persons may have the following definition:
 

--- a/data-definition/Definition-syntax.rst
+++ b/data-definition/Definition-syntax.rst
@@ -1,5 +1,6 @@
 Definition syntax 
 =================
+.. todo?: provide unique index example?
 
 The table definition consist of lines.  Each line can be one of the following:
 
@@ -12,6 +13,7 @@ The table definition consist of lines.  Each line can be one of the following:
   - ``name = default : datatype  # comment``
 * The divider ``---`` (at least three dashes) separating primary key attributes above from non-primary attributes below.
 * A foreign key in the format ``-> ReferencedTable``. (See :doc:`Foreign-keys`.)
+* A ``unique index`` attribute modifier in the format ``unique index(attribute, ...)``.
 
 For example, the table for Persons may have the following definition:
 


### PR DESCRIPTION
2 nits:

- Data-types.md link xrefs are directly to target .html files; unclear if
  sphinx->recommonmark allows for more generic linking.

  Apparently recommonmark passes through links to sphinx in the :any: role,
  and quick tests with 'bare' document word didn't "take". Left as-is since
  primary output is HTML, potentially easier to fix by simply converting page
  to .rst than fiddling with md->sphinx mappings, unless somone knows the
  magic incantation.

  See also:
  - http://recommonmark.readthedocs.io/en/latest/index.html#links
  - http://www.sphinx-doc.org/en/stable/markup/inline.html

- Documentation of 'unique index' feature is provided without concrete example;
  didn't want to 'pollute' the existing 'simple' example by it's addition,
  not sure if best to add here directly, or create a secondary block
  duplicating the 'persons' example but also showing the use of this syntax.