### PR TITLE
Edit 'Create a schema' for terminology and clarity.

### DIFF
--- a/contents/definition/01-create-schema.rst
+++ b/contents/definition/01-create-schema.rst
@@ -87,8 +87,6 @@ The returned object ``schema`` will then serve as a decorator for DataJoint clas
 
 It is a common practice to have a separate Python module for each schema.  Therefore, each such module has only one ``dj.schema`` object defined and is usually named ``schema``.
 
-In previous releases of DataJoint, the second argument of ``dj.schema`` was the context in which future table declarations would look for other classes. This argument was nearly always simply ``locals()``, which is now the current default. The second argument can still be provided, for compatibility and to allow for overriding, but this is optional.
-
 Working with existing data
 --------------------------
 What if the database schema already exists?  For example, what if we created the schema in Python but want to access the data from MATLAB or vice versa?  No problem.  Follow the same process for creating the schema and specify the existing database name.  We will show how to work with existing tables later.

--- a/contents/definition/01-create-schema.rst
+++ b/contents/definition/01-create-schema.rst
@@ -79,14 +79,15 @@ Create a new schema using the ``dj.schema`` function:
 .. code-block:: python
 
     import datajoint as dj
-    schema = dj.schema('alice_experiment', locals())
+    schema = dj.schema('alice_experiment')
 
 This statement creates the database schema ``alice_experiment`` on the server.
-The second argument of ``dj.schema`` is the context in which future table declarations will look for other classes; this argument will nearly always need to be simply ``locals()``.
 
 The returned object ``schema`` will then serve as a decorator for DataJoint classes, as described in :doc:`02-create-table`.
 
 It is a common practice to have a separate Python module for each schema.  Therefore, each such module has only one ``dj.schema`` object defined and is usually named ``schema``.
+
+In previous releases of DataJoint, the second argument of ``dj.schema`` was the context in which future table declarations would look for other classes. This argument was nearly always simply ``locals()``, which is now the current default. The second argument can still be provided, for compatibility and to allow for overriding, but this is optional.
 
 Working with existing data
 --------------------------

--- a/contents/definition/01-create-schema.rst
+++ b/contents/definition/01-create-schema.rst
@@ -4,26 +4,26 @@ Create a schema
 
 Relational Data Model
 ---------------------
-DataJoint organizes data using the *Relational Data Model*.  This means that all data are stored in collections of simple tables or, in mathematical lingo, *relations*. 
+DataJoint organizes data using the *Relational Data Model*.  This means that all data are stored in collections of simple tables.
 
 See also :doc:`../concepts/2-terminology`
- 
+
 Classes represent tables
 ------------------------
 To make it easy to work with tables in MATLAB and Python, DataJoint programs create a separate class for each table.  Computer programmers refer to this concept as `object-relational mapping <https://en.wikipedia.org/wiki/Object-relational_mapping>`_.  For example, the class ``experiment.Subject`` in MATLAB or Python may correspond to the table called ``experiment.subject`` on the database server.
-Users never need to see the database directly and interact with data in the database by creating and interacting with DataJoint classes.   
+Users never need to see the database directly; they only interact with data in the database by creating and interacting with DataJoint classes.
 
 Schemas
 -------
-On the database server, related tables are grouped into a named collection called **database** or **schema**.  This allows organizing the data and controlling access by users.  Therefore, we need a way of associating DataJoint classes with their schema.  This way we may address tables as ``schema.TableClassName``.  Before we create any tables, we must create a schema.
+On the database server, related tables are grouped into a named collection called a **database** or a **schema**.  This grouping organizes the data and allows control of user access.  DataJoint reflects this organization by associating each DataJoint class with its corresponding schema, by addressing tables as ``schema.TableClassName``.  Therefore, we must create a schema before we can create any tables.
 
 |matlab| MATLAB
 ---------------------------
-There are two equivalent ways to create a schema in MATLAB: manual and automated using the ``dj.createSchema`` script.  While ``dj.createSchema`` simplifies the process, the manual approach yields a better understand of what actually takes place.  Therefore, we list both approaches:
+A schema can be created in MATLAB manually or automatically through the ``dj.createSchema`` script.  While ``dj.createSchema`` simplifies the process, the manual approach yields a better understanding of what actually takes place, so both approaches are listed below.
 
-Manually
+Manual
 ^^^^^^^^^^^^
-**Step 1.**  Create the database
+**Step 1.**  Create the database schema
 
 Use the following command to create a new database on the server:
 
@@ -31,20 +31,20 @@ Use the following command to create a new database on the server:
 
     query(dj.conn, 'CREATE SCHEMA `alice_experiment`')
 
-Note that you must have create privileges for the database name pattern (as described in [Database hosting]).  It is a common practice to grant all privileges to users to databases that begin with the username in addition to some shared databases.  Thus the user ``alice`` would be able to perform any work in any database that begins with ``alice_``.
+Note that you must have create privileges for the database name pattern (as described in :doc:`../setup/Database-hosting`).  It is a common practice to grant all privileges to users for databases that begin with the username, in addition to some shared databases.  Thus the user ``alice`` would be able to perform any work in any database that begins with ``alice_``.
 
 **Step 2.**  Create the MATLAB package
 
-DataJoint for matlab organizes schemas as MATLAB packages. If you are not familiar with them, please review
+DataJoint for MATLAB organizes schemas as MATLAB **packages**. If you are not familiar with packages, please review:
 
-* how to work with MATLAB **packages**: https://www.mathworks.com/help/matlab/matlab_oop/scoping-classes-with-packages.html 
-* how to manage MATLAB's **search paths** work: https://www.mathworks.com/help/matlab/search-path.html.
+* `How to work with MATLAB packages <https://www.mathworks.com/help/matlab/matlab_oop/scoping-classes-with-packages.html>`_
+* `How to manage MATLAB's search paths <https://www.mathworks.com/help/matlab/search-path.html>`_
 
-In your project directory, create the package folder, which must begin with a ``+`` sign.  For example, for the schema called ``experiment``, you would create the folder ``+experiment``.  Make sure that your project directory (the parent directory of your package folder) is added to the MATLAB search path. 
+In your project directory, create the package folder, which must begin with a ``+`` sign.  For example, for the schema called ``experiment``, you would create the folder ``+experiment``.  Make sure that your project directory (the parent directory of your package folder) is added to the MATLAB search path.
 
 **Step 3.**  Associate the package with the database schema
 
-In this step, we will tell DataJoint that all classes in the package folder ``+experiment`` will work with tables in the database schema ``alice_experiment``. 
+In this step, we tell DataJoint that all classes in the package folder ``+experiment`` will work with tables in the database schema ``alice_experiment``.
 
 In the ``+experiment`` folder, create the file ``getSchema.m`` with the following contents:
 
@@ -60,10 +60,10 @@ In the ``+experiment`` folder, create the file ``getSchema.m`` with the followin
 
 This function returns a persistent object of type ``dj.Schema``, establishing the link between the ``experiment`` package in MATLAB and the database ``alice_experiment`` on the database server.
 
-Automatically
+Automatic
 ^^^^^^^^^^^^^
 
-Alternatively, you can execute 
+Alternatively, you can execute
 
 .. code-block:: matlab
 
@@ -81,8 +81,8 @@ Create a new schema using the ``dj.schema`` function:
     import datajoint as dj
     schema = dj.schema('alice_experiment', locals())
 
-This statement creates the database ``alice_experiment`` on the server.  
-The second argument of ``dj.schema`` is the contexts in which future table declarations will look for other classes; this argument will nearly always need to be simply ``locals()``.
+This statement creates the database schema ``alice_experiment`` on the server.
+The second argument of ``dj.schema`` is the context in which future table declarations will look for other classes; this argument will nearly always need to be simply ``locals()``.
 
 The returned object ``schema`` will then serve as a decorator for DataJoint classes, as described in :doc:`02-create-table`.
 
@@ -90,7 +90,7 @@ It is a common practice to have a separate Python module for each schema.  There
 
 Working with existing data
 --------------------------
-What if the database already exists?  For example, what if we created the schema in Python but want to access the data from MATLAB or vice versa?  No problem.  Follow the same process for creating the schema and specify the existing database name.  We will show how to work with existing tables later.
+What if the database schema already exists?  For example, what if we created the schema in Python but want to access the data from MATLAB or vice versa?  No problem.  Follow the same process for creating the schema and specify the existing database name.  We will show how to work with existing tables later.
 
 .. |matlab| image:: ../_static/img/matlab-tiny.png
 .. |python| image:: ../_static/img/python-tiny.png


### PR DESCRIPTION
Removed reference to relations, per our previous terminology discussions.
Made some grammar and syntax edits, as well as some changes that I think add clarity.
Changed "database" to "database schema" for disambiguation. Perhaps we should discuss the terminology here.