### PR TITLE
Make lab names consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# JetBrains
+.idea/
+
 # Cache files
 .DS_Store
 ~*

--- a/contents/intro/05-who.rst
+++ b/contents/intro/05-who.rst
@@ -8,19 +8,19 @@ to meet the needs of their own research.
 
 Below is a partial list of known DataJoint users.  Please let us know if you would like to add another lab or make a correction.
 
-1. Andreas Tolias' Lab -- Baylor College of Medicine
-#. International Brain Laboratory (www.internationalbrainlab.com)
-#. Mesoscale Activity Project (https://www.simonsfoundation.org/funded-project/%20multi-regional-neuronal-dynamics-of-memory-guided-flexible-behavior/)
+1. Tolias Lab (Andreas Tolias), Baylor College of Medicine
+#. `International Brain Laboratory <https://www.internationalbrainlab.com>`_
+#. `Mesoscale Activity Project <https://www.simonsfoundation.org/funded-project/%20multi-regional-neuronal-dynamics-of-memory-guided-flexible-behavior/>`_
 #. Siapas Lab (Athanassios G. Siapas), California Institute of Technology
 #. Svoboda Lab (Karel Svoboda), Janelia Research Campus
-#. Nuo Li's Lab, Baylor College of Medicine
+#. Li Lab (Nuo Li), Baylor College of Medicine
 #. Mouse Motor Lab (MacKenzie Mathis), Rowland Institute at Harvard University
 #. Busse Lab (Laura Busse), Werner Reichardt Centre for Integrative Neuroscience, Tübingen, Germany
-#. Sinz Lab (Fabian Sinz), Wilhelm Schickard Institue for Computer Science, Cyber Valley Initiative, University Tübingen (https://sinzlab.org)
+#. `Sinz Lab <https://sinzlab.org>`_ (Fabian Sinz), Wilhelm Schickard Institue for Computer Science, Cyber Valley Initiative, University Tübingen
 #. Berens Lab (Philipp Berens), Werner Reichardt Centre for Integrative Neuroscience, Tübingen, Germany
 #. Euler Lab (Thomas Euler), Werner Reichardt Centre for Integrative Neuroscience, Tübingen, Germany
 #. Katzner Lab (Steffen Katzner), Werner Reichardt Centre for Integrative Neuroscience, Tübingen, Germany
 #. Bethge Lab (Matthias Bethge), Werner Reichardt Centre for Integrative Neuroscience, Tübingen, Germany
 #. Moser Group, Kavli Institute for Systems Neuroscience and Centre for Neural Computation, Norwegian University of Science and Technology (NTNU), Trondheim, Norway
-#. Seung Lab, Princeton University
-#. Christopher Harvey's Lab, Harvard Medical School
+#. Seung Lab (Sebastian Seung), Princeton University
+#. Harvey Lab (Christopher Harvey), Harvard Medical School

--- a/contents/intro/05-who.rst
+++ b/contents/intro/05-who.rst
@@ -21,6 +21,6 @@ Below is a partial list of known DataJoint users.  Please let us know if you wou
 #. Euler Lab (Thomas Euler), Werner Reichardt Centre for Integrative Neuroscience, Tübingen, Germany
 #. Katzner Lab (Steffen Katzner), Werner Reichardt Centre for Integrative Neuroscience, Tübingen, Germany
 #. Bethge Lab (Matthias Bethge), Werner Reichardt Centre for Integrative Neuroscience, Tübingen, Germany
-#. Moser Group, Kavli Institute for Systems Neuroscience and Centre for Neural Computation, Norwegian University of Science and Technology (NTNU), Trondheim, Norway
+#. Moser Group (May-Britt Moser and Edvard Moser), Kavli Institute for Systems Neuroscience and Centre for Neural Computation, Norwegian University of Science and Technology (NTNU), Trondheim, Norway
 #. Seung Lab (Sebastian Seung), Princeton University
 #. Harvey Lab (Christopher Harvey), Harvard Medical School


### PR DESCRIPTION
* Make lab naming consistent (e.g. `{special name|last name} Lab ({full name}), {institution}`)
* Make lab or group name the hyper link