### PR TITLE
Split index.rst by language. Fix link formatting in Contribute and FAQs.

### DIFF
--- a/contents/index.rst
+++ b/contents/index.rst
@@ -3,7 +3,7 @@
 Welcome to DataJoint Documentation
 ====================================
 
-This is a detailed manual for active users of DataJoint in Python and MATLAB. 
+.. include:: index_lang1.rst
 
 This documentation can be read sequentially from start to end or used as reference for specific topics.
 
@@ -26,7 +26,7 @@ For a guided introduction to DataJoint, please explore our tutorials at http://t
    :maxdepth: 2
    :includehidden:
 
-   setup/Setup.rst 
+   setup/Setup.rst
 
 .. toctree::
    :maxdepth: 2

--- a/contents/intro/11-Contribute.rst
+++ b/contents/intro/11-Contribute.rst
@@ -5,12 +5,13 @@
 Contribute
 ==========
 
-This documentation is published on the website https://docs.datajoint.io and may be distributed under the terms of the :ref:`license <license>` with a required reference to https://docs.datajoint.io and copyright to *DataJoint Contributors*.
+This documentation is published on the `DataJoint website <https://docs.datajoint.io>`_.
+The documentation may be distributed under the terms of the :ref:`license <license>` with a required reference to https://docs.datajoint.io and copyright to *DataJoint Contributors*.
 
-The master source for this documentation is hosted at https://github.com/datajoint/datajoint-docs.
-To report an issue with the documentation, please use the issue tracker https://github.com/datajoint/datajoint-docs.
+The master source for this documentation is hosted on GitHub at https://github.com/datajoint/datajoint-docs.
+To report an issue with the documentation, please use the `issue tracker <https://github.com/datajoint/datajoint-docs/issues>`_.
 
-To contribute, fork the documentation from https://github.com/datajoint/datajoint-docs into a personal GitHub repository.
-Upon completing the contribution, please issue a `pull request <https://help.github.com/articles/about-pull-requests/>` for review by the core DataJoint contributors.
-The documentation must be written in RestrcturedText using `Sphinx conventions <http://www.sphinx-doc.org/en/master/usage/restructuredtext/>`
-The README file of the repository provides instructions for building the documentation and writing style guidelines.
+To contribute, fork the documentation `repository <https://github.com/datajoint/datajoint-docs>`_ into a personal GitHub repository.
+Upon completing the contribution, please issue a `pull request <https://help.github.com/articles/about-pull-requests/>`_ for review by the core DataJoint contributors.
+The documentation must be written in RestrcturedText using `Sphinx conventions <http://www.sphinx-doc.org/en/master/usage/restructuredtext/>`_
+The README file of the repository provides instructions for building the documentation as well as writing style guidelines.

--- a/contents/intro/12-FAQs.rst
+++ b/contents/intro/12-FAQs.rst
@@ -14,20 +14,20 @@ Does DataJoint support other programming languages?
 ---------------------------------------------------
 DataJoint was originally developed to support MATLAB, followed by Python.
 DataJoint's data model and data representation are largely language independent, which means that any language with a DataJoint client can work with a data pipeline defined in any other language.
-DataJoint clients will be implemented for other programming languages based on the demand.
+DataJoint clients for other programming languages will be implemented based on demand.
 All languages must comply to the same data model and computation approach as defined in `DataJoint: a simpler relational data model <https://arxiv.org/abs/1807.11104>`_.
 
 Is DataJoint another ORM?
 -------------------------
-Programmers are familiar with ORM: object-relational mappings in various programming languages.
-Python in particular has several popular ORMs such as `SQLAlchemy <https://www.sqlalchemy.org/>`_ and `Django ORM <https://tutorial.djangogirls.org/en/django_orm/>`.
-The purpose of ORMs is to allow representing and manipulating objects from the host programming language as data in a relational database.
-ORMs allow making objects persistent between program execution.
+Programmers are familiar with object-relational mappings (ORM) in various programming languages.
+Python in particular has several popular ORMs such as `SQLAlchemy <https://www.sqlalchemy.org/>`_ and `Django ORM <https://tutorial.djangogirls.org/en/django_orm/>`_.
+The purpose of ORMs is to allow representations and manipulations of objects from the host programming language as data in a relational database.
+ORMs allow making objects persistent between program executions.
 ORMs create a bridge or a **mapping** between the object model used by the host language and the relational model allowed by the database.
 The result is always a compromise, usually toward the object model.
 ORMs usually forgo key concepts, features, and capabilities of the relational model for the sake of convenient programming constructs in the language.
 
-In contrast, DataJoint implements a data model that is a refinement of the relational data model and adheres to it faithfully without compromising its principles.
+In contrast, DataJoint implements a data model that is a refinement of the relational data model and that adheres to it faithfully without compromising its principles.
 DataJoint supports data integrity (entity integrity, referential integrity, and group integrity) and provides a fully capable relational query language.
 DataJoint remains absolutely data-centric, with the primary focus on the structure and integrity of the data pipeline.
 Other ORMs are more application-centric, primarily focusing on the application design while the database plays a secondary role supporting the application with object persistence and sharing.
@@ -44,7 +44,7 @@ Alyx is an application with a fixed pipeline design with a nice graphical user i
 In contrast, DataJoint is a general-purpose library for designing and building data processing pipelines.
 
 Alyx is geared towards ease of data entry and tracking for a specific workflow (e.g. mouse colony information and some pre-specified experiments) and data types.
-DataJoint could be used as a more general purposes tool to design, implement, and also execute processing on such workflow/pipeline from scratch, and DataJoint focuses on flexibility, data integrity and ease of data analysis.
+DataJoint could be used as a more general purposes tool to design, implement, and execute processing on such workflows/pipelines from scratch, and DataJoint focuses on flexibility, data integrity, and ease of data analysis.
 The purposes are partly overlapping and complementary.
-The `International Brain Lab project <https://internationalbrainlab.com>`_ is developing a bridge from Alyx to DataJoint, hosted as an `open-source project <https://github.com/vathes/ibl-pipeline>`.
+The `International Brain Lab project <https://internationalbrainlab.com>`_ is developing a bridge from Alyx to DataJoint, hosted as an `open-source project <https://github.com/vathes/ibl-pipeline>`_.
 It implements a DataJoint schema that replicates the major features of the Alyx application and a synchronization script from an existing Alyx database to its DataJoint counterpart.


### PR DESCRIPTION
This PR is dependent on PRs to [datajoint-python](https://github.com/datajoint/datajoint-python/pull/527) and [datajoint-matlab](https://github.com/datajoint/datajoint-matlab/pull/132).  The language-specific PRs should be merged **_before_** merging this PR.