### PR TITLE
add shading to tables, fix figure order and size issue

### DIFF
--- a/contents/conf.py
+++ b/contents/conf.py
@@ -142,6 +142,7 @@ latex_elements = {
     # Latex figure (float) alignment
     # 'figure_align' set to 'H' makes the figures appear strictly in the order it was inserted in the doc
     'figure_align': 'H',
+    # 'pxunit' : '0.7227bp',
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',

--- a/contents/conf.py
+++ b/contents/conf.py
@@ -138,6 +138,10 @@ latex_elements = {
                   '\\fi'),
 
     'sphinxsetup': 'VerbatimColor={rgb}{0.9, 0.9, 0.9}, VerbatimBorderColor={rgb}{0.85,0.85,0.85}',
+    'passoptionstopackages': r'\PassOptionsToPackage{table}{xcolor}',
+    # Latex figure (float) alignment
+    # 'figure_align' set to 'H' makes the figures appear strictly in the order it was inserted in the doc
+    'figure_align': 'H',
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
@@ -150,8 +154,8 @@ latex_elements = {
     #
     'preamble':  r'''
     \usepackage{txfonts}
-    \usepackage{xcolor}
     \definecolor{light-gray}{gray}{0.9}
+    \rowcolors{2}{light-gray}{white}
     \addto\captionsenglish{\renewcommand{\contentsname}{Table of Contents}}
     \setcounter{tocdepth}{1}
     \makeatletter
@@ -159,10 +163,10 @@ latex_elements = {
     \newcommand{\@sphinxupquotecolor}{light-gray}
     \newcommand{\sphinxupquotecolor}[1]{\renewcommand{\@sphinxupquotecolor}{}}
     \makeatother
-
     '''
 
-    
+
+    #\usepackage[table]{xcolor}
     #\sphinxcode{\sphinxupquote{experiment.Session}} needed to be styled with light gray background
     # \makeatletter
     # \renewcommand{\sphinxupquote}{\colorbox{\@sphinxupquotecolor}}
@@ -170,9 +174,7 @@ latex_elements = {
     # \newcommand{\sphinxupquotecolor}[1]{\renewcommand{\@sphinxupquotecolor}{}}
     # \makeatother
 
-    # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
+    
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/contents/intro/01-Data-Pipelines.rst
+++ b/contents/intro/01-Data-Pipelines.rst
@@ -39,11 +39,22 @@ Data pipelines
 
   Therefore, a full-featured data pipeline framework may also be described as a `scientific workflow system <https://en.wikipedia.org/wiki/Scientific_workflow_system>`_.
 
-.. figure:: ../_static/img/pipeline-database.png
-    :align: center
-    :alt: data pipelines vs databases vs data repositories
+.. only:: html
 
-    Major features of data management frameworks: data repositories, databases, and data pipelines.
+    .. figure:: ../_static/img/pipeline-database.png
+        :align: center
+        :alt: data pipelines vs databases vs data repositories
+
+        Major features of data management frameworks: data repositories, databases, and data pipelines.
+
+.. only:: latex
+
+    .. figure:: ../_static/img/pipeline-database.png
+        :width: 220px
+        :align: center
+        :alt: data pipelines vs databases vs data repositories
+
+        Major features of data management frameworks: data repositories, databases, and data pipelines.
 
 What is DataJoint?
 ------------------
@@ -56,6 +67,7 @@ The pipeline may have some nodes requiring manual data entry or import from exte
 In a typical scenario, experimenters and acquisition instruments feed data into nodes at the head of the pipeline, while downstream nodes perform automated computations for data processing and analysis.
 
 .. figure:: ../_static/img/pipeline.png
+    :width: 250px
     :align: center
     :alt: A data pipeline
 

--- a/contents/intro/02-Teamwork.rst
+++ b/contents/intro/02-Teamwork.rst
@@ -12,6 +12,7 @@ Science labs organize their projects as a sequence of activities of experiment d
 
 
 .. figure:: ../_static/img/data-science-before.png
+    :width: 520px
     :align: center
     :alt: data science in a science lab
 
@@ -30,6 +31,7 @@ This approach requires formulating a general data science plan and upfront inves
 The team uses DataJoint to build data pipelines to support multiple projects.
 
 .. figure:: ../_static/img/data-science-after.png
+    :width: 510px
     :align: center
     :alt: data science in a science lab
 
@@ -55,6 +57,7 @@ Team roles
 The adoption of a uniform data management framework allows separation of roles and division of labor among team members, leading to greater efficiency and better scaling.
 
 .. figure:: ../_static/img/data-engineering.png
+    :width: 350px
     :align: center
     :alt: data science vs engineering
 

--- a/contents/queries/05-Operators.rst
+++ b/contents/queries/05-Operators.rst
@@ -67,15 +67,36 @@ Examples
 ^^^^^^^^
 This is a matching pair of entities:
 
-.. image:: ../_static/img/matched_tuples1.png
+.. only:: html
+
+    .. image:: ../_static/img/matched_tuples1.png
+        :width: 366px
+
+.. only:: latex
+
+    .. image:: ../_static/img/matched_tuples1.png
 
 and so is this one:
 
-.. image:: ../_static/img/matched_tuples2.png
+.. only:: html
+
+    .. image:: ../_static/img/matched_tuples2.png
+        :width: 366px
+
+.. only:: latex
+
+    .. image:: ../_static/img/matched_tuples2.png
 
 but these entities do *not* match:
 
-.. image:: ../_static/img/matched_tuples3.png
+.. only:: html
+
+    .. image:: ../_static/img/matched_tuples3.png
+        :width: 366px
+
+.. only:: latex
+
+    .. image:: ../_static/img/matched_tuples3.png
 
 .. _join-compatible:
 

--- a/contents/queries/06-Restriction.rst
+++ b/contents/queries/06-Restriction.rst
@@ -12,6 +12,7 @@ The restriction operator ``A & cond`` selects the subset of entities from ``A`` 
 The exclusion operator ``A - cond`` selects the complement of restriction, i.e. the subset of entities from  ``A`` that do not meet the condition ``cond``.
 
 .. figure:: ../_static/img/op-restrict.png
+    :width: 400px
     :align: center
     :alt: Restriction and exclusion
 
@@ -32,15 +33,35 @@ When restricting table ``A`` with another table, written ``A & B``, the two tabl
 The result will contain all entities from ``A`` for which there exist a matching entity in ``B``.
 Exclusion of table ``A`` with table ``B``, or ``A - B``, will contain all entities from ``A`` for which there are no matching entities in ``B``.
 
-.. figure:: ../_static/img/restrict-example1.png
-    :alt: Restriction by another table
+.. only:: html
 
-    Restriction by another table.
+    .. figure:: ../_static/img/restrict-example1.png
+        :width: 546px
+        :align: center
+        :alt: Restriction by another table
 
-.. figure:: ../_static/img/diff-example1.png
-    :alt: Exclusion by another table
+        Restriction by another table.
 
-    Exclusion by another table.
+    .. figure:: ../_static/img/diff-example1.png
+        :width: 539px
+        :align: center
+        :alt: Exclusion by another table
+
+        Exclusion by another table.
+
+.. only:: latex
+
+    .. figure:: ../_static/img/restrict-example1.png
+        :align: center
+        :alt: Restriction by another table
+
+        Restriction by another table.
+
+    .. figure:: ../_static/img/diff-example1.png
+        :align: center
+        :alt: Exclusion by another table
+
+        Exclusion by another table.
 
 Restriction by a table with no common attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -48,15 +69,36 @@ Restriction by a table with no common attributes
 Restriction of table ``A`` with another table ``B`` having none of the same attributes as ``A`` will simply return all entities in ``A``, unless ``B`` is empty as described below.
 Exclusion of table ``A`` with ``B`` having no common attributes will return no entities, unless ``B`` is empty as described below.
 
-.. figure:: ../_static/img/restrict-example2.png
-   :alt: Restriction by a table with no common attributes
+.. only:: html
 
-   Restriction by a table having no common attributes.
+    .. figure:: ../_static/img/restrict-example2.png
+        :width: 571px
+        :align: center
+        :alt: Restriction by a table with no common attributes
 
-.. figure:: ../_static/img/diff-example2.png
-   :alt: Exclusion by a table having no common attributes
+        Restriction by a table having no common attributes.
 
-   Exclusion by a table having no common attributes.
+    .. figure:: ../_static/img/diff-example2.png
+        :width: 571px
+        :align: center
+        :alt: Exclusion by a table having no common attributes
+
+        Exclusion by a table having no common attributes.
+
+.. only:: latex
+
+    .. figure:: ../_static/img/restrict-example2.png
+        :align: center
+        :alt: Restriction by a table with no common attributes
+
+        Restriction by a table having no common attributes.
+
+    .. figure:: ../_static/img/diff-example2.png
+        :align: center
+        :alt: Exclusion by a table having no common attributes
+
+        Exclusion by a table having no common attributes.
+
 
 Restriction by an empty table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,15 +106,35 @@ Restriction by an empty table
 Restriction of table ``A`` with an empty table will return no entities regardless of whether there are any matching attributes.
 Exclusion of table ``A`` with an empty table will return all entities in ``A``.
 
-.. figure:: ../_static/img/restrict-example3.png
-   :alt: Restriction by an empty table
+.. only:: html
 
-   Restriction by an empty table.
+    .. figure:: ../_static/img/restrict-example3.png
+        :width: 563px
+        :align: center
+        :alt: Restriction by an empty table
 
-.. figure:: ../_static/img/diff-example3.png
-   :alt: Exclusion by an empty table
+        Restriction by an empty table.
 
-   Exclusion by an empty table.
+    .. figure:: ../_static/img/diff-example3.png
+        :width: 571px
+        :align: center
+        :alt: Exclusion by an empty table
+
+        Exclusion by an empty table.
+
+.. only:: latex
+
+    .. figure:: ../_static/img/restrict-example3.png
+        :align: center
+        :alt: Restriction by an empty table
+
+        Restriction by an empty table.
+
+    .. figure:: ../_static/img/diff-example3.png
+        :align: center
+        :alt: Exclusion by an empty table
+
+        Exclusion by an empty table.
 
 Restriction by a query
 ----------------------

--- a/contents/queries/07-Join.rst
+++ b/contents/queries/07-Join.rst
@@ -22,18 +22,48 @@ Examples of joins
 
 Example 1 : When the operands have no common attributes, the result is the cross product -- all combinations of entities.
 
-.. figure:: ../_static/img/join-example1.png
-   :alt:
+.. only:: html
+
+    .. figure:: ../_static/img/join-example1.png
+        :width: 464px
+        :align: center
+        :alt:
+
+.. only:: latex
+
+    .. figure:: ../_static/img/join-example1.png
+        :align: center
+        :alt:
 
 Example 2 : When the operands have common attributes, only entities with matching values are kept.
 
-.. figure:: ../_static/img/join-example2.png
-   :alt:
+.. only:: html
+
+    .. figure:: ../_static/img/join-example2.png
+        :width: 689px
+        :align: center
+        :alt:
+
+.. only:: latex
+
+    .. figure:: ../_static/img/join-example2.png
+        :align: center
+        :alt:
 
 Example 3 : Joining on secondary attribute.
 
-.. figure:: ../_static/img/join-example3.png
-   :alt:
+.. only:: html
+
+    .. figure:: ../_static/img/join-example3.png
+        :width: 689px
+        :align: center
+        :alt:
+
+.. only:: latex
+
+    .. figure:: ../_static/img/join-example3.png
+        :align: center
+        :alt:
 
 Properties of join
 ~~~~~~~~~~~~~~~~~~

--- a/contents/queries/10-Union.rst
+++ b/contents/queries/10-Union.rst
@@ -37,13 +37,33 @@ Examples of union
 
 Example 1 : Note that the order of the attributes does not matter.
 
-.. figure:: ../_static/img/union-example1.png
-   :alt:
+.. only:: html
+
+    .. figure:: ../_static/img/union-example1.png
+        :width: 404px
+        :align: center
+        :alt:
+
+.. only:: latex
+
+    .. figure:: ../_static/img/union-example1.png
+        :align: center
+        :alt:
 
 Example 2 : Non-key attributes are combined from both tables and filled with NULLs when missing.
 
-.. figure:: ../_static/img/union-example2.png
-   :alt:
+.. only:: html
+
+    .. figure:: ../_static/img/union-example2.png
+        :width: 539px
+        :align: center
+        :alt:
+
+.. only:: latex
+
+    .. figure:: ../_static/img/union-example2.png
+        :align: center
+        :alt:
 
 Properties of union
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#115 - add alternating shading to rows (not columns) for improved pdf table view
#106, #107 - addressed size issue for the smaller figures in both pdf and website 
#161 - the figures are now positioned strictly in the order they are introduced in document