### PR TITLE
improve legibility of table on pdf, slightly shrink a figure

### DIFF
--- a/contents/admin/5-blob-config.rst
+++ b/contents/admin/5-blob-config.rst
@@ -69,26 +69,54 @@ DataJoint organizes external storage to preserve the same data integrity princip
 
    Below are sample entries in ``~external``.
 
-    .. list-table:: ~external
-       :widths: 12 12 12 12 12
-       :header-rows: 1
+   .. only:: latex
 
-       * - STORAGE
-         - HASH
-         - count
-         - size
-         - timestamp
-       * - raw
-         - 1GEqtEU6JYEOLS4sZHeHDxWQ3JJfLlHVZio1ga25vd2
-         - 3
-         - 1039536788
-         - 2017-06-07 23:14:01
-       * -
-         - wqsKbNB1LKSX7aLEV+ACKWGr-XcB6+h6x91Wrfh9uf7
-         - 0
-         - 168849430
-         - 2017-06-07 22:47:58
+      .. list-table:: ~external
+            :widths: 3 10 2 3 5 
+            :header-rows: 1
 
+            * - STORAGE
+              - HASH
+              - count
+              - size
+              - timestamp
+            * - raw
+              - 1GEqtEU6JYEOLS4sZHeHDxWQ3JJfLlH VZio1ga25vd2
+              - 3
+              - 1039536788
+              - 2017-06-07 23:14:01
+            * - 
+              - wqsKbNB1LKSX7aLEV+ACKWGr-XcB6+h6x91Wrfh9uf7
+              - 0
+              - 168849430
+              - 2017-06-07 22:47:58
+   
+   .. only:: html
+    
+        .. |br| unicode::  U+2028 .. line separator
+            :trim:
+
+        .. list-table:: ~external
+            :widths: auto
+            :header-rows: 1
+            :align: center
+
+            * - STORAGE
+              - HASH
+              - count
+              - size
+              - timestamp
+            * - raw
+              - 1GEqtEU6JYE |br| OLS4sZHeHDx |br| WQ3JJfLlHVZ |br| io1ga25vd2
+              - 3
+              - 1039536788
+              - 2017-06-07 23:14:01
+            * - 
+              - wqsKbNB1LKS |br| X7aLEV+ACKW |br| Gr-XcB6+h6x |br| 91Wrfh9uf7
+              - 0
+              - 168849430
+              - 2017-06-07 22:47:58
+        
 6. Attributes of type ``external`` are declared as renamed :ref:`foreign keys <dependencies>` referencing the ``~external`` table (but are not shown as such to the user).
 
 7. The :ref:`insert <insert>` operation first saves all the external objects in the external storage, then inserts the corresponding entities in ``~external`` for new data or increments the ``count`` for duplicates.

--- a/contents/setup/02-DataJoint-Python-Windows-Install-Guide.rst
+++ b/contents/setup/02-DataJoint-Python-Windows-Install-Guide.rst
@@ -50,6 +50,7 @@ Step 2: verify installation
 To verify the Python installation and make sure that your system is ready to install DataJoint, open a command window by entering ``cmd`` into the Windows search bar:
 
 .. image:: ../_static/img/windows/cmd-prompt.png
+  :width: 42%
 
 From here ``python`` and the Python package manager ``pip`` can be verified by running ``python -V`` and ``pip -V``, respectively:
 


### PR DESCRIPTION
- the pdf version of the table in chapter 2.5 (external store) was broken so this commit addresses that.  The website version of the same table is also now wider with hidden linebreaks for improved visibility.
- also shrunk one of the larger figures in the setup chapter. 