### PR TITLE
update readme and tag selection logic in the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ largely based on the [Read The Doc theme](https://github.com/rtfd/sphinx_rtd_the
 The documentation can be distributed for free use under the [Creative Commons Attribution-ShareAlike 4.0 International Public License](https://creativecommons.org/licenses/by-sa/4.0/).  Any copy or derivation of the documentation must include attribution to "DataJoint contributors" and include the URL reference https://docs.datajoint.io
 
 
-# In-Development: Building All Versions (Full Site)
+# Building All Versions (Full Site)
 1. Clone the repository to your local machine.
 2. The default setting will build using `datajoint/datajoint-docs.git`, `datajoint/datajoint-matlab.git` and `datajoint/datajoint-python.git` repo. If you'd like to change the repo that the build points to, modify the content of the `build_config_template.py` and rename the file to `build_config.py` (follow the instruction inside the template file for further instructions) 
 3. Build the website by running `python build-all.py`. This will build and generate the static website in the `full_site` directory.
@@ -23,7 +23,7 @@ The documentation can be distributed for free use under the [Creative Commons At
 6. If you made changes to the documentation source but you're not seeing the changes reflected, that is because this command builds from contents that are already pushed and tagged in the git repository. Please build locally to test, and then push with updated version numbers to see the changes in the full_site building.
 7. To stop the server, hit `Ctrl+C` in the terminal window that's running the server.
 
-# In-Development: Building Locally/Partially 
+# Building Locally/Partially 
 1. Fork and clone the repository to your local machine. Note: datajoint-docs now only contains the common documentions. If you are writing for a specific language, you also need to clone the datajoint-matlab or datajoint-python repository and make sure they are placed on the same level as the datajoint-docs folder. 
 2. If you have the Python/MATLAB repository for local development/building and the folders aren't named `datajoint-python`/`datajoint-matlab` or have them somewhere other than on the same level as the `datajoint-docs` folder, open the `build_config_template.py` and set the new path inside, then rename the config file to `build_config.py` (follow the instruction inside the template file for further instructions)
 3. Build the website by running `python build-local.py`. This will build and generate the static website in the `loc_built_site` directory. 
@@ -43,12 +43,12 @@ Note 3: If for some reason, you don't want to build using the local common versi
 # Notes on Tagging
 1. Before you tag anything, please `git tag` to make sure you see the current tag status.
 2. In the `datajoint-docs` folder, `build-version.json` specifies which language versions to build in the build-all/full-build-mode. If you specify v3.2 in matlab, then the site will be built using the most recent tag (ex. v3.2.5 will be used to build, not v3.2.4). 
-3. In the language-specific folder, all documentation contents are inside the `/docs` directory. Inside, you will see a `_version_common.json` file, which should only contain one corresponding common version tag for this language folder to be build alongside. Note that this file specifies the full-tag version (ex. v0.0.3) for the common version.
-(Not sure about how we will coordinate this with the team yet: When you update content in the lang-specific documentation and you also have made changes in the common version to reflect the change, make sure you give a new tag to the common version, update this `_version_common.json` with the new tag, then also add a new tag (should we?) for the specific language version.)
-4. to add a tag: `git tag -a v3.2.5 -m "some message"`
-   to delete local tag: `git tag -d v3.2.5`
-   to delete already-pushed tag: `git push origin :refs/tags/v3.2.5`
-   to push with tag `git push origin v3.2.5`
+3. In the language-specific folder, all documentation contents are inside the `/docs-parts` directory. Inside, you will see a `_version_common.json` file, which should only contain one corresponding common version tag for this language folder to be build alongside. This file specifies the version (ex. v0.0) for the common version. Similar to the build process described above, if v0.0 is specified in the `_version_common.json`, then the most recent tag, for example v0.0.5 instead of v0.0.4 will be grabbed for the build.
+4. - to add a doc specific tag to `datajoint-python` or `datajoint-matlab` repo, make sure to add the `-doc#` ending: `git tag -a v3.2.5-doc1 -m "some message"`. The # should be an integer.
+   - to add a common doc tag to `datajoint-docs` repo, no special ending is necessary: `git tag -a v0.0.1 -m "some message`
+   - to delete local tag: `git tag -d v3.2.5-doc1`
+   - to delete already-pushed tag: `git push origin :refs/tags/v3.2.5-doc1`
+   - to push with tag `git push origin v0.0.3`
 
 
 # Guidelines for Writing

--- a/build-all.py
+++ b/build-all.py
@@ -7,6 +7,7 @@ import subprocess
 import platform
 from collections import defaultdict
 from util import get_newest_tag 
+from util import get_newest_doc_tag
 from util import copy_contents
 
 # default values in case the build config file is missing
@@ -28,7 +29,9 @@ def create_build_folders(lang):
         print(f)
         min_tags = json.load(f)
 
-    tags = [get_newest_tag(t, raw_tags) for t in min_tags[lang]]
+    # tags = [get_newest_tag(t, raw_tags) for t in min_tags[lang]]
+    tags = [get_newest_doc_tag(t, raw_tags) for t in min_tags[lang]] # returns ['v3.2.14-doc12', 'v3.3.9-doc9] format
+
 
     for tag in tags:
         subprocess.Popen(["git", "checkout", tag],
@@ -125,7 +128,7 @@ def make_full_site():
             print("Latex environment not set up - no pdf will be generated")
 
         lang_version = folder.split(os.sep)[1]  # 'matlab-v3.2.2'
-        lang, version = lang_version.split("-")   # e.g. 'matlab',  'v3.2.2'
+        lang, version, doc_version = lang_version.split("-")   # e.g. 'matlab',  'v3.2.2'
         abbr_ver = '.'.join(version.split('.')[:-1])  # e.g. 'v3.2'
         abbr_lang_ver = lang + '-' + abbr_ver
 

--- a/util.py
+++ b/util.py
@@ -43,6 +43,7 @@
 import os
 import os.path as path
 import shutil
+import re
 
 # returns the newest full tag (to the patch) given an abbreviated version (to minor version)
 # get_newest_tag("v3.2", ["v3.1.6", "v3.2.0", "v3.2.1", "v3.2.2", "v3.2.14", "v3.3.1", "v3.3.2-dev.5","v3.3.3"])
@@ -70,6 +71,37 @@ def get_newest_tag(given_tag, raw_tags):
                 # print("building version " + ver)
                 return ver
 
+
+def get_newest_doc_tag(given_tag, raw_tags):
+    doc_tags = []
+    doc_tags_cropped = []
+    for doc_tag in raw_tags:
+        m = re.search(r'.*-doc\d+$', doc_tag)
+        # if the doc_tag ends in -docs+digits m will be a Match object, or None otherwise.
+        if m is not None:
+            # print(m.group())
+            doc_tags_cropped.append(m.group().split("-")[0])
+            doc_tags.append(m.group())
+
+    # print(doc_tags)
+    # print(doc_tags_cropped)
+
+    # get_newest_tag(given_tag, doc_tags_cropped) gives the newest full tag (v3.2.18) for the specified tag (v3.2)
+
+    to_sort = [dtag for dtag in doc_tags if dtag.startswith(get_newest_tag(given_tag, doc_tags_cropped))]
+    # print(to_sort)
+    tag_nums = []
+    for d in to_sort:
+        m = re.search(r'\d+$', d)
+        if m is not None:
+            tag_num = int(m.group())
+            # print (m.group())
+            tag_nums.append(tag_num)
+    print(tag_nums)
+    for d in to_sort:
+        if d.endswith(str(max(tag_nums))):
+            # print(d)
+            return d  # v3.2.2-doc11
 
 def copy_contents(src_dir, dest_dir, skip_fpattern=None, skip_dpattern=None):
     for root, dirnames, filenames in os.walk(src_dir):


### PR DESCRIPTION
- update README.md with new instructions on tagging.
- make sure the build picks up the new tag ending `-doc#` in the build-all mode.