### PR TITLE
Fix inaccurate docs in `.aggr()` with `median()` and other non MySQL operations

### DIFF
--- a/contents/queries/09-Aggr.rst
+++ b/contents/queries/09-Aggr.rst
@@ -10,7 +10,7 @@ It has the form ``tab.aggr(other, ...)`` where ``other`` is another table.
 Without the argument ``other``, ``aggr`` and ``proj`` are exactly equivalent.
 Aggregation allows adding calculated attributes to each entity in ``tab`` based on aggregation functions over attributes in the :ref:`matching <matching>` entities of ``other``.
 
-Aggregation functions include ``count``, ``sum``, ``min``, ``max``, ``avg``, ``median``, ``percentile``, ``stdev``, ``var``, and others.
+Aggregation functions include ``count``, ``sum``, ``min``, ``max``, ``avg``, ``std``, ``variance``, and others.
 Aggregation functions can only be used in the definitions of new attributes within the ``aggr`` operator.
 
 As with ``proj``, the output of ``aggr`` has the same entity class, the same primary key, and the same number of elements as ``tab``.


### PR DESCRIPTION
Fix #253 