### PR TITLE
Remove outdated ref to ability to drop part table only

### DIFF
--- a/contents/definition/14-Drop.rst
+++ b/contents/definition/14-Drop.rst
@@ -21,5 +21,3 @@ Dropping part tables
 --------------------
 
 A :ref:`part table <master-part>` is usually removed as a consequence of calling ``drop`` on its master table.
-
-.. include:: 14-Drop_lang2.rst


### PR DESCRIPTION
[14-Drop_lang2](https://github.com/datajoint/datajoint-python/blob/master/docs-parts/definition/14-Drop_lang2.rst) refers to the ability to force-drop a part table. This ability was intentionally removed in [0.13.3](https://github.com/datajoint/datajoint-python/releases/tag/v0.13.3) 